### PR TITLE
remove-expired: Report expired keys as not found

### DIFF
--- a/backends/postgresql/session_postgresql.ml
+++ b/backends/postgresql/session_postgresql.ml
@@ -103,7 +103,7 @@ let get (t:t) key =
     let expiry = Scanf.sscanf (result#getvalue 0 0) "%Ld" (fun x -> x) in
     let period = Int64.(sub expiry (now ())) in
     if Int64.compare period 0L < 0 then
-      Result.Error Session.S.Expired
+      Result.Error Session.S.Not_found
     else if result#getvalue 0 1 = null then
       Result.Error Session.S.Not_set
     else

--- a/lib/memory.ml
+++ b/lib/memory.ml
@@ -68,7 +68,7 @@ let get t key =
     let result = Hashtbl.find t.store key in
     let period = Int64.(sub result.expiry (now ())) in
     if Int64.compare period 0L < 0 then
-      Result.Error S.Expired
+      Result.Error S.Not_found
     else match result.value with
     | None       -> Result.Error S.Not_set
     | Some value -> Result.Ok(value, period)

--- a/lib/s.mli
+++ b/lib/s.mli
@@ -43,7 +43,6 @@ open Result
 type error =
   | Not_found   (** The key was not found. *)
   | Not_set     (** The key was found but had no associated value. *)
-  | Expired     (** The key has expired. It may still be in the backend. *)
 
 (** The signature for synchronous backends.
 

--- a/lib_test/test_memory_backend.ml
+++ b/lib_test/test_memory_backend.ml
@@ -1,7 +1,6 @@
 module Backend = struct
   include Session.Memory
   let name = "memory"
-  let expired = Session.S.Expired
 end
 
 let () = Nocrypto_entropy_unix.initialize ()

--- a/lib_test/test_postgresql_backend.ml
+++ b/lib_test/test_postgresql_backend.ml
@@ -7,8 +7,6 @@ module Backend = struct
     let open Postgresql in
     ignore (t#exec ~expect:[Command_ok] "DELETE FROM session");
     t
-
-  let expired = Session.S.Expired
 end
 
 let () =

--- a/lib_test/test_redis_backend.ml
+++ b/lib_test/test_redis_backend.ml
@@ -30,8 +30,6 @@ module Backend = struct
 
   let set ?expiry t key value =
     Lwt_main.run (C.set ?expiry t key value)
-
-  let expired = Session.S.Not_found
 end
 
 let () = Nocrypto_entropy_unix.initialize ()

--- a/lib_test/test_session.ml
+++ b/lib_test/test_session.ml
@@ -8,7 +8,6 @@ module type Backend = sig
 
   val name : string
   val create : unit -> t
-  val expired : Session.S.error
 end
 
 module Make(B:Backend) = struct
@@ -20,7 +19,6 @@ module Make(B:Backend) = struct
   let err_to_string = function
     | Session.S.Not_found -> "Not_found"
     | Session.S.Not_set   -> "Not_set"
-    | Session.S.Expired   -> "Expired"
 
   let from_ok = function
     | Result.Ok x      -> x
@@ -80,8 +78,8 @@ module Make(B:Backend) = struct
     let key1 = B.generate ~expiry:(-10L) backend in
     assert_equal ~msg:"getting a garbage key will produce a Not_found error"
       (Result.Error Session.S.Not_found) (get backend "asdfjk") ~printer;
-    assert_equal ~msg:"getting an expired, unset session will produce an Expired error"
-      (Result.Error B.expired) (get backend key1) ~printer;
+    assert_equal ~msg:"getting an expired, unset session will produce a Not_found error"
+      (Result.Error Session.S.Not_found) (get backend key1) ~printer;
 
     let key2 = B.generate backend in
     assert_equal ~msg:"getting an unexpired, unset session will produce a Not_set error"
@@ -94,8 +92,8 @@ module Make(B:Backend) = struct
       (Result.Error Session.S.Not_found) (get backend key2) ~printer;
 
     let key3 = B.generate ~expiry:(-1000L) ~value:"data2" backend in
-    assert_equal ~msg:"getting an expired, set key will produce an Expired error"
-      (Result.Error B.expired) (get backend key3) ~printer;
+    assert_equal ~msg:"getting an expired, set key will produce a Not_found error"
+      (Result.Error Session.S.Not_found) (get backend key3) ~printer;
   ;;
 
   let rec was_successful =


### PR DESCRIPTION
There's little utility in reporting that a key has expired. Instead, simply report that it was unable to be found. Responsibility for clearing expired keys is still the responsibility of the individual backends.