### PR TITLE
fix-opam-files: use correct names

### DIFF
--- a/session-cohttp-async.opam
+++ b/session-cohttp-async.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "session"
+name: "session-cohttp-async"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"

--- a/session-cohttp-lwt.opam
+++ b/session-cohttp-lwt.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "session"
+name: "session-cohttp-lwt"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"

--- a/session-cohttp.opam
+++ b/session-cohttp.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "session"
+name: "session-cohttp"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"

--- a/session-postgresql-async.opam
+++ b/session-postgresql-async.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "session"
+name: "session-postgresql-async"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"

--- a/session-postgresql-lwt.opam
+++ b/session-postgresql-lwt.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "session"
+name: "session-postgresql-lwt"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"

--- a/session-postgresql.opam
+++ b/session-postgresql.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "session"
+name: "session-postgresql"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"

--- a/session-redis-lwt.opam
+++ b/session-redis-lwt.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "session"
+name: "session-redis-lwt"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"

--- a/session-webmachine.opam
+++ b/session-webmachine.opam
@@ -1,5 +1,5 @@
 opam-version: "1.2"
-name: "session"
+name: "session-webmachine"
 maintainer: "Spiros Eliopoulos <spiros@inhabitedtype.com>"
 authors: [ "Spiros Eliopoulos <spiros@inhabitedtype.com>" ]
 license: "BSD-3-clause"


### PR DESCRIPTION
This commit includes the same changes that had to made in ocaml/opam-repository#10288.

Introduced in #16.