### PR TITLE
postgresql-lwt-fix: support Lwt 4.0

### DIFF
--- a/backends/postgresql/lwt/jbuild
+++ b/backends/postgresql/lwt/jbuild
@@ -3,4 +3,4 @@
 (library
   ((name        session_postgresql_lwt)
    (public_name session-postgresql-lwt)
-   (libraries   (lwt postgresql result session-postgresql threads))))
+   (libraries   (lwt lwt.unix postgresql result session-postgresql threads))))

--- a/session-postgresql-lwt.opam
+++ b/session-postgresql-lwt.opam
@@ -15,5 +15,5 @@ build: [
 depends: [
   "jbuilder" {build & >= "1.0+beta9"}
   "session-postgresql"
-  "lwt"
+  "lwt" {>= "3.2.0"}
 ]


### PR DESCRIPTION
From Lwt 4.0.0,  `lwt.preemptive` is no longer available.

<https://github.com/ocsigen/lwt/releases/tag/4.0.0>
>- Delete package lwt.preemptive. It is an alias for lwt.unix since Lwt 3.2.0 (#487).