### PR TITLE
Configure Travis to test the main session package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ env:
   - OCAML_VERSION=4.10 PACKAGE=session-redis-lwt
   - OCAML_VERSION=4.07 PACKAGE=session-postgresql-lwt
   - OCAML_VERSION=4.08 PACKAGE=session-postgresql-async
+  - OCAML_VERSION=4.10 PACKAGE=session


### PR DESCRIPTION
The main `session` package's tests failed opam-repo-ci: https://github.com/ocaml/opam-repository/pull/19138#pullrequestreview-718241044

Looks like they're not being run by Travis here.