### PR TITLE
Use {=version} in opam files

### DIFF
--- a/session-cohttp-async.opam
+++ b/session-cohttp-async.opam
@@ -9,7 +9,7 @@ doc: "https://inhabitedtype.github.io/ocaml-session/"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "session-cohttp" {>= "0.4.2"}
+  "session-cohttp" {= version}
   "cohttp-async"
   "async"
   "base-threads"

--- a/session-cohttp-lwt.opam
+++ b/session-cohttp-lwt.opam
@@ -9,7 +9,7 @@ doc: "https://inhabitedtype.github.io/ocaml-session/"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "session-cohttp" {>= "0.4.2"}
+  "session-cohttp" {= version}
   "cohttp-lwt"
   "lwt"
 ]

--- a/session-cohttp.opam
+++ b/session-cohttp.opam
@@ -9,7 +9,7 @@ doc: "https://inhabitedtype.github.io/ocaml-session/"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "session" {>= "0.4.2"}
+  "session" {= version}
   "cohttp" {>= "0.99.0"}
 ]
 build: [

--- a/session-postgresql-async.opam
+++ b/session-postgresql-async.opam
@@ -9,7 +9,7 @@ doc: "https://inhabitedtype.github.io/ocaml-session/"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "session-postgresql" {>= "0.4.2"}
+  "session-postgresql" {= version}
   "async"
   "base-threads"
 ]

--- a/session-postgresql-lwt.opam
+++ b/session-postgresql-lwt.opam
@@ -9,7 +9,7 @@ doc: "https://inhabitedtype.github.io/ocaml-session/"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "session-postgresql" {>= "0.4.2"}
+  "session-postgresql" {= version}
   "lwt" {>= "3.2.0"}
 ]
 build: [

--- a/session-postgresql.opam
+++ b/session-postgresql.opam
@@ -9,7 +9,7 @@ doc: "https://inhabitedtype.github.io/ocaml-session/"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "session" {>= "0.4.2"}
+  "session" {= version}
   "postgresql"
 ]
 build: [

--- a/session-redis-lwt.opam
+++ b/session-redis-lwt.opam
@@ -9,7 +9,7 @@ doc: "https://inhabitedtype.github.io/ocaml-session/"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "session" {>= "0.4.2"}
+  "session" {= version}
   "redis-lwt"
 ]
 build: [

--- a/session-webmachine.opam
+++ b/session-webmachine.opam
@@ -9,7 +9,7 @@ doc: "https://inhabitedtype.github.io/ocaml-session/"
 depends: [
   "ocaml" {>= "4.07.0"}
   "dune" {>= "1.0"}
-  "session-cohttp" {>= "0.4.2"}
+  "session-cohttp" {= version}
   "webmachine"
 ]
 build: [


### PR DESCRIPTION
`opam pin` on this repo fails due to version constrains. This PR fixes it.