### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name session)
  (public_name session)
- (libraries mirage-crypto-rng base64))
+ (libraries mirage-crypto-rng base64 unix))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.