### PR TITLE
fix-ci: add cohttp-lwt-unix as a test dependency

### DIFF
--- a/session-cohttp-lwt.opam
+++ b/session-cohttp-lwt.opam
@@ -11,6 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "session-cohttp" {= version}
   "cohttp-lwt"
+  "cohttp-lwt-unix" { with-test }
   "lwt"
 ]
 build: [


### PR DESCRIPTION
Fix ocaml ci, with the exception of one alpine build that has some weird ssl conflict.

Closes #33.